### PR TITLE
Simple fix for help message "optional arguments"

### DIFF
--- a/src/main/java/net/sourceforge/argparse4j/internal/ArgumentParserImpl.java
+++ b/src/main/java/net/sourceforge/argparse4j/internal/ArgumentParserImpl.java
@@ -288,7 +288,7 @@ public final class ArgumentParserImpl implements ArgumentParser {
         }
         if (checkDefaultGroup(optargs_)) {
             writer.println();
-            writer.println("optional arguments:");
+            writer.println("arguments:");
             printArgumentHelp(writer, optargs_, formatWidth);
         }
         if (subparsers_.hasSubCommand() && !subparsersUntitled) {


### PR DESCRIPTION
I propose this simple fix, just call everyting "arguments". The usage message already clearly identifies the optional arguments and the required ones. This way users are not mislead into thinking that they are all optional.
