### PR TITLE
Adds ReflectArgumentFlag

### DIFF
--- a/src/main/java/net/sourceforge/argparse4j/impl/type/EnumStringArgumentType.java
+++ b/src/main/java/net/sourceforge/argparse4j/impl/type/EnumStringArgumentType.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2015 Andrew January
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.sourceforge.argparse4j.impl.type;
+
+import net.sourceforge.argparse4j.helper.TextHelper;
+import net.sourceforge.argparse4j.inf.Argument;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.ArgumentType;
+
+/**
+ * <p>
+ * ArgumentType subclass for enum type.
+ * </p>
+ * <p>
+ * Uses {@link Enum#toString()} instead of {@link Enum#name()} as the String
+ * representation of the enum. For enums that do not override {@link Enum#toString()},
+ * this behaves the same as {@link ReflectArgumentType}.
+ *
+ * @param <T>
+ *            Type of enum
+ */
+public class EnumStringArgumentType<T extends Enum<T>> implements ArgumentType<T> {
+
+    private Class<T> type_;
+
+    public EnumStringArgumentType(Class<T> type) {
+        type_ = type;
+    }
+
+    /**
+     * <p>
+     * Creates an {@code EnumStringArgumentType} for the given enum type.
+     * @param type
+     *            type of the enum the {@code EnumStringArgumentType} should convert to
+     * @return an {@code EnumStringArgumentType} that converts Strings to {@code type} 
+     */
+    public static <T extends Enum<T>> EnumStringArgumentType<T> forEnum(Class<T> type) {
+        return new EnumStringArgumentType<T>(type);
+    }
+
+    @Override
+    public T convert(ArgumentParser parser, Argument arg, String value)
+            throws ArgumentParserException {
+        for (T t : type_.getEnumConstants()) {
+            if (t.toString().equals(value)) {
+                return t;
+            }
+        }
+
+        String choices = TextHelper.concat(type_.getEnumConstants(), 0,
+                ",", "{", "}");
+        throw new ArgumentParserException(String.format(
+                TextHelper.LOCALE_ROOT,
+                "could not convert '%s' (choose from %s)", value, choices),
+                parser, arg);
+    }
+}

--- a/src/test/java/net/sourceforge/argparse4j/impl/type/EnumStringArgumentTypeTest.java
+++ b/src/test/java/net/sourceforge/argparse4j/impl/type/EnumStringArgumentTypeTest.java
@@ -1,0 +1,41 @@
+package net.sourceforge.argparse4j.impl.type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.mock.MockArgument;
+
+import org.junit.Test;
+
+public class EnumStringArgumentTypeTest {
+
+    enum Lang {
+        PYTHON, JAVA, CPP {
+            @Override
+            public String toString() {
+                return "C++";
+            }
+        }
+    }
+
+    @Test
+    public void testConvert() throws ArgumentParserException {
+        EnumStringArgumentType<Lang> type = EnumStringArgumentType.forEnum(Lang.class);
+        assertEquals(Lang.PYTHON, type.convert(null, null, "PYTHON"));
+        assertEquals(Lang.JAVA, type.convert(null, null, "JAVA"));
+        assertEquals(Lang.CPP, type.convert(null, null, "C++"));
+    }
+
+    @Test
+    public void testConvertErrorsWithUnknownMember() throws ArgumentParserException {
+        EnumStringArgumentType<Lang> type = EnumStringArgumentType.forEnum(Lang.class);
+        try {
+            type.convert(null, new MockArgument(), "CPP");
+            fail("Expected ArgumentParserException to be thrown");
+        } catch (ArgumentParserException e) {
+            assertEquals(
+                    "argument null: could not convert 'CPP' (choose from {PYTHON,JAVA,C++})",
+                    e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Adds ReflectArgumentFlag with ENUM_USE_TO_STRING to force
ReflectArgumentType to use the toString instead of name as the String
representation of an enum.

This addresses #43 in a way that is backwards compatible while retaining
some of the ergonomics of the current ReflectArgumentType for enums.