### PR TITLE
Introduce MetavarInference interface, and infer Boolean metavar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
+				<version>2.10.3</version>
 				<configuration>
 					<locale>en</locale>
 				</configuration>
@@ -114,7 +114,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
-				<version>3.0</version>
+				<version>3.3</version>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
@@ -148,7 +148,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
+				<version>2.10.3</version>
 				<configuration>
 					<locale>en</locale>
 					<stylesheet>maven</stylesheet>

--- a/src/main/java/net/sourceforge/argparse4j/impl/type/ReflectArgumentType.java
+++ b/src/main/java/net/sourceforge/argparse4j/impl/type/ReflectArgumentType.java
@@ -32,14 +32,22 @@ import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.ArgumentType;
+import net.sourceforge.argparse4j.inf.MetavarInference;
 
 /**
  * <p>
  * This implementation converts String value into given type using type's
  * {@code valueOf(java.lang.String)} static method or its constructor.
+ * 
+ * This class implements {@link MetavarInference} interface, and performs
+ * special handling when {@link Boolean} class is passed to the constructor. In
+ * that case, {@link ReflectArgumentType#inferMetavar()} returns convenient
+ * metavar string for Boolean values, and it is used when
+ * {@link Argument#metavar(String...)} is not used.
  * </p>
  */
-public class ReflectArgumentType<T> implements ArgumentType<T> {
+public class ReflectArgumentType<T> implements ArgumentType<T>,
+        MetavarInference {
 
     private Class<T> type_;
 
@@ -152,5 +160,21 @@ public class ReflectArgumentType<T> implements ArgumentType<T> {
 
     private void handleInstatiationError(Exception e) {
         throw new IllegalArgumentException("reflect type conversion error", e);
+    }
+
+    /**
+     * If {@link Boolean} class is passed to constructor, this method returns
+     * metavar string "{true,false}" for convenience.
+     * 
+     * @see net.sourceforge.argparse4j.inf.MetavarInference#inferMetavar()
+     */
+    @Override
+    public String[] inferMetavar() {
+        if (!Boolean.class.equals(type_)) {
+            return null;
+        }
+
+        return new String[] { TextHelper.concat(
+                new String[] { "true", "false" }, 0, ",", "{", "}") };
     }
 }

--- a/src/main/java/net/sourceforge/argparse4j/inf/MetavarInference.java
+++ b/src/main/java/net/sourceforge/argparse4j/inf/MetavarInference.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 Tatsuhiro Tsujikawa
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.sourceforge.argparse4j.inf;
+
+/**
+ * This interface provides a way to infer metavar strings from a context which
+ * implements this interface.
+ * 
+ */
+public interface MetavarInference {
+
+    /**
+     * <p>
+     * Returns inferred array of metavar strings.
+     * </p>
+     * <p>
+     * The returned array is treated like when strings are given in
+     * {@link Argument#metavar(String...)}.
+     * </p>
+     * 
+     * @return inferred array of metavar strings, or null if there is no metavar
+     *         inferred.
+     */
+    String[] inferMetavar();
+}

--- a/src/main/java/net/sourceforge/argparse4j/internal/ArgumentImpl.java
+++ b/src/main/java/net/sourceforge/argparse4j/internal/ArgumentImpl.java
@@ -43,6 +43,7 @@ import net.sourceforge.argparse4j.inf.ArgumentChoice;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.ArgumentType;
 import net.sourceforge.argparse4j.inf.FeatureControl;
+import net.sourceforge.argparse4j.inf.MetavarInference;
 
 /**
  * <strong>The application code must not use this class directly.</strong>
@@ -169,6 +170,12 @@ public final class ArgumentImpl implements Argument {
 
     public String[] resolveMetavar() {
         if (metavar_ == null) {
+            if (type_ instanceof MetavarInference) {
+                String[] metavar = ((MetavarInference) type_).inferMetavar();
+                if (metavar != null) {
+                    return metavar;
+                }
+            }
             String[] metavar = new String[1];
             if (choice_ == null) {
                 metavar[0] = isOptionalArgument() ? dest_.toUpperCase() : dest_;

--- a/src/site/sphinx/usage.rst
+++ b/src/site/sphinx/usage.rst
@@ -1301,6 +1301,27 @@ that simply check against a range of values::
 
 See :ref:`Argument-choices` for more details.
 
+In some cases, type itself may infer metavar.  In that case, it is
+more convenient to get metavar from type instead of setting metavar
+for each argument.  To achieve this, if
+:javadoc:`inf.MetavarInference` is implemented as well, it can infer
+metavar through its interface method.  We mentioned that special
+handling of ``Boolean.class`` for default metavar in
+:ref:`Argument-metavar` section.  It is implemented using
+:javadoc:`inf.MetavarInference`.  Here is an example of implementation
+of :javadocfunc:`inf.MetavarInference.inferMetavar()` from
+:javadoc:`impl.ReflectArgumentType`::
+
+    @Override
+    public String[] inferMetavar() {
+        if (!Boolean.class.equals(type_)) {
+            return null;
+        }
+
+        return new String[] { TextHelper.concat(
+                new String[] { "true", "false" }, 0, ",", "{", "}") };
+    }
+
 .. _Argument-choices:
 
 Argument.choices()
@@ -1467,6 +1488,8 @@ When :javadoc:`inf.ArgumentParser` generates help messages, it need
 some way to referer to each expected argument. By default,
 :javadoc:`inf.ArgumentParser` objects use the "dest" value (see
 :ref:`Argument-dest` about "dest" value) as the "name" of each object.
+If ``Boolean.class`` is given to |Argument.type|, and if no metavar is set,
+``{true,false}`` is used as metavar automatically for convenience.
 By default, for positional arguments, the dest value is used directly,
 and for optional arguments, the dest value is uppercased. So, a single
 positional argument with ``dest("bar")`` will be referred to as

--- a/src/test/java/net/sourceforge/argparse4j/internal/ArgumentImplTest.java
+++ b/src/test/java/net/sourceforge/argparse4j/internal/ArgumentImplTest.java
@@ -133,7 +133,14 @@ public class ArgumentImplTest {
         arg.nargs("+");
         assertEquals("ALPHA [BRAVO ...]", arg.formatMetavar());
     }
-    
+
+    @Test
+    public void testFormatMetavarWithMetavarInference() {
+        ArgumentImpl arg = new ArgumentImpl(prefix, "--foo")
+                .type(Boolean.class);
+        assertEquals("{true,false}", arg.formatMetavar());
+    }
+
     @Test
     public void testConvert() throws ArgumentParserException {
         ArgumentImpl arg = new ArgumentImpl(prefix, "--foo");


### PR DESCRIPTION
Previously, when Boolean.class is passed to Argument#type(), and no
metavar is provided, the help message was like "-f F".  This is
intentional, and expected, but it is better for user to show them F is
true or false.  This commit introduce MetavarInference interface.
When sub class of ArgumentType also implements MetavarInference, it
can infer metavar from its interface.  We made ReflectArgumentType
implement this interface, and if Boolean.class is given for its
constructor, then return useful Boolean value metavar from
inferMetavar() method.