### PR TITLE
parseArgsOrFail should exit 0 on HelpScreenException

### DIFF
--- a/src/main/java/net/sourceforge/argparse4j/internal/ArgumentParserImpl.java
+++ b/src/main/java/net/sourceforge/argparse4j/internal/ArgumentParserImpl.java
@@ -573,6 +573,9 @@ public final class ArgumentParserImpl implements ArgumentParser {
         try {
             Namespace ns = parseArgs(args);
             return ns;
+        } catch (HelpScreenException e) {
+            handleError(e);
+            System.exit(0);
         } catch (ArgumentParserException e) {
             handleError(e);
             System.exit(1);
@@ -585,6 +588,9 @@ public final class ArgumentParserImpl implements ArgumentParser {
         try {
             Namespace ns = parseKnownArgs(args, unknown);
             return ns;
+        } catch (HelpScreenException e) {
+            handleError(e);
+            System.exit(0);
         } catch (ArgumentParserException e) {
             handleError(e);
             System.exit(1);


### PR DESCRIPTION
My expectation is that `something --help` should exit 0.

Some examples:
```shell
$ git --help > /dev/null; echo $?
0
$ brew --help > /dev/null; echo $?
0
$ mvn --help > /dev/null; echo $?
0
```

The implementation could just as well use `instanceof` if that is preferable.

```java
    public Namespace parseArgsOrFail(String args[]) {
        try {
            Namespace ns = parseArgs(args);
            return ns;
        } catch (ArgumentParserException e) {
            handleError(e);
            if (e instanceof HelpScreenException) {
                System.exit(0);
            }
            System.exit(1);
        }
        return null;
    }
```