### PR TITLE
Added argument types to parse enum value names in case-insensitive manner

### DIFF
--- a/src/main/java/net/sourceforge/argparse4j/impl/Arguments.java
+++ b/src/main/java/net/sourceforge/argparse4j/impl/Arguments.java
@@ -36,6 +36,8 @@ import net.sourceforge.argparse4j.impl.action.StoreTrueArgumentAction;
 import net.sourceforge.argparse4j.impl.action.VersionArgumentAction;
 import net.sourceforge.argparse4j.impl.choice.RangeArgumentChoice;
 import net.sourceforge.argparse4j.impl.type.BooleanArgumentType;
+import net.sourceforge.argparse4j.impl.type.CaseInsensitiveEnumNameArgumentType;
+import net.sourceforge.argparse4j.impl.type.CaseInsensitiveEnumStringArgumentType;
 import net.sourceforge.argparse4j.impl.type.EnumArgumentType;
 import net.sourceforge.argparse4j.impl.type.EnumStringArgumentType;
 import net.sourceforge.argparse4j.impl.type.FileArgumentType;
@@ -288,6 +290,45 @@ public final class Arguments {
     public static <T extends Enum<T>> EnumStringArgumentType<T> enumStringType(
             Class<T> type) {
         return new EnumStringArgumentType<T>(type);
+    }
+
+    /**
+     * <p>
+     * Returns {@link CaseInsensitiveEnumNameArgumentType} with given enum
+     * {@code type}.
+     * </p>
+     * <p>
+     * Uses {@link Enum#name()} as the String representation of the enum.
+     * </p>
+     *
+     * @param type
+     *            The enum type
+     * @return {@link CaseInsensitiveEnumNameArgumentType} object
+     */
+    public static <T extends Enum<T>> CaseInsensitiveEnumNameArgumentType<T>
+            caseInsensitiveEnumType(Class<T> type) {
+        return new CaseInsensitiveEnumNameArgumentType<T>(type);
+    }
+
+    /**
+     * <p>
+     * Returns {@link CaseInsensitiveEnumStringArgumentType} with given enum
+     * {@code type}.
+     * </p>
+     * <p>
+     * Uses {@link Enum#toString()} instead of {@link Enum#name()} as the String
+     * representation of the enum. For enums that do not override
+     * {@link Enum#toString()}, this behaves the same as
+     * {@link CaseInsensitiveEnumNameArgumentType}.
+     * </p>
+     * 
+     * @param type
+     *            The enum type
+     * @return {@link CaseInsensitiveEnumStringArgumentType} object
+     */
+    public static <T extends Enum<T>> CaseInsensitiveEnumStringArgumentType<T> 
+            caseInsensitiveEnumStringType(Class<T> type) {
+        return new CaseInsensitiveEnumStringArgumentType<T>(type);
     }
 
     /**

--- a/src/main/java/net/sourceforge/argparse4j/impl/type/CaseInsensitiveEnumArgumentType.java
+++ b/src/main/java/net/sourceforge/argparse4j/impl/type/CaseInsensitiveEnumArgumentType.java
@@ -1,0 +1,81 @@
+package net.sourceforge.argparse4j.impl.type;
+
+import java.util.Locale;
+
+import net.sourceforge.argparse4j.helper.TextHelper;
+import net.sourceforge.argparse4j.inf.Argument;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.ArgumentType;
+import net.sourceforge.argparse4j.inf.MetavarInference;
+
+public abstract class CaseInsensitiveEnumArgumentType<T extends Enum<T>>
+        implements ArgumentType<T>, MetavarInference {
+    protected Class<T> type_;
+    
+    protected CaseInsensitiveEnumArgumentType(Class<T> type) {
+        this.type_ = type;
+    }
+
+    @Override
+    public T convert(ArgumentParser parser, Argument arg, String value)
+            throws ArgumentParserException {
+        String valueForComparison = toCaseInsensitiveForm(value);
+        for (T t : type_.getEnumConstants()) {
+            // Not using "equalsIgnoreCase(String)" as this will cause tests
+            // "testIgnoresLocaleOfParserForCaseInsensitivity" of the subclasses
+            // to fail.
+            if (toCaseInsensitiveForm(toStringRepresentation(t))
+                    .equals(valueForComparison)) {
+                return t;
+            }
+        }
+
+        String choices = TextHelper.concat(getStringRepresentations(), 0,
+                ",", "{", "}");
+        throw new ArgumentParserException(String.format(
+                TextHelper.LOCALE_ROOT,
+                "could not convert '%s' (choose from %s)", value, choices),
+                parser, arg);
+    }
+
+    protected abstract String toStringRepresentation(T t);
+
+    /**
+     * <p>
+     * Infers metavar based on given type.
+     * </p>
+     * <p>
+     * The inferred metavar contains all enum constant string representation.
+     * </p>
+     *
+     * @see MetavarInference#inferMetavar()
+     * @since 0.7.0
+     */
+    @Override
+    public String[] inferMetavar() {
+        return new String[] { TextHelper.concat(getStringRepresentations(),
+                0, ",", "{", "}") };
+    }
+
+    /**
+     * <p>
+     * Get the objects to be used to generate the String representations of all
+     * enum constants. {@link Object#toString()} will be invoked on these
+     * objects to obtain the actual String representation.
+     * </p>
+     * @return The objects used to generate String representations.
+     */
+    protected abstract Object[] getStringRepresentations();
+
+    /**
+     * Get the String representation of the given value.
+     * 
+     * @param value
+     *            The value for which to get the String representation.
+     * @return The String representation of <code>value</code>.
+     */
+    private String toCaseInsensitiveForm(String value) {
+        return value.toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/net/sourceforge/argparse4j/impl/type/CaseInsensitiveEnumNameArgumentType.java
+++ b/src/main/java/net/sourceforge/argparse4j/impl/type/CaseInsensitiveEnumNameArgumentType.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 Andrew January
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.sourceforge.argparse4j.impl.type;
+
+/**
+ * <p>
+ * ArgumentType subclass for enum type using case-insensitive matching of
+ * values.
+ * </p>
+ * <p>
+ * Uses {@link Enum#name()} as the String representation of the enum.
+ *
+ * @param <T>
+ *            Type of enum
+ */
+public class CaseInsensitiveEnumNameArgumentType<T extends Enum<T>>
+        extends CaseInsensitiveEnumArgumentType<T> {
+
+    public CaseInsensitiveEnumNameArgumentType(Class<T> type) {
+        super(type);
+    }
+
+    /**
+     * <p>
+     * Creates a {@code CaseInsensitiveEnumNameArgumentType} for the given enum
+     * type.
+     *
+     * @param type
+     *         type of the enum the {@code CaseInsensitiveEnumNameArgumentType}
+     *         should convert to
+     * @return a {@code CaseInsensitiveEnumNameArgumentType} that converts
+     * Strings to {@code type}
+     */
+    public static <T extends Enum<T>> CaseInsensitiveEnumNameArgumentType<T>
+            forEnum(Class<T> type) {
+        return new CaseInsensitiveEnumNameArgumentType<T>(type);
+    }
+
+    @Override
+    protected String toStringRepresentation(T t) {
+        return t.name();
+    }
+
+    @Override
+    protected Object[] getStringRepresentations() {
+        T[] enumConstants = type_.getEnumConstants();
+        Object[] names = new String[enumConstants.length];
+        for (int i = 0; i < enumConstants.length; i++) {
+            names[i] = enumConstants[i].name();
+        }
+        return names;
+    }
+}

--- a/src/main/java/net/sourceforge/argparse4j/impl/type/CaseInsensitiveEnumStringArgumentType.java
+++ b/src/main/java/net/sourceforge/argparse4j/impl/type/CaseInsensitiveEnumStringArgumentType.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2015 Andrew January
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.sourceforge.argparse4j.impl.type;
+
+/**
+ * <p>
+ * ArgumentType subclass for enum type using case-insensitive matching of
+ * values.
+ * </p>
+ * <p>
+ * Uses {@link Enum#toString()} instead of {@link Enum#name()} as the String
+ * representation of the enum. For enums that do not override
+ * {@link Enum#toString()}, this behaves the same as
+ * {@link CaseInsensitiveEnumNameArgumentType}.
+ *
+ * @param <T>
+ *            Type of enum
+ */
+public class CaseInsensitiveEnumStringArgumentType<T extends Enum<T>>
+        extends CaseInsensitiveEnumArgumentType<T> {
+
+    public CaseInsensitiveEnumStringArgumentType(Class<T> type) {
+        super(type);
+    }
+
+    /**
+     * <p>
+     * Creates a {@code CaseInsensitiveEnumStringArgumentType} for the given
+     * enum type.
+     *
+     * @param type
+     *         type of the enum the {@code CaseInsensitiveEnumStringArgumentType}
+     *         should convert to
+     * @return a {@code CaseInsensitiveEnumStringArgumentType} that converts
+     * Strings to {@code type}
+     */
+    public static <T extends Enum<T>> CaseInsensitiveEnumStringArgumentType<T> 
+            forEnum(Class<T> type) {
+        return new CaseInsensitiveEnumStringArgumentType<T>(type);
+    }
+
+    @Override
+    protected String toStringRepresentation(T t) {
+        return t.toString();
+    }
+
+    @Override
+    protected Object[] getStringRepresentations() {
+        return type_.getEnumConstants();
+    }
+}

--- a/src/site/sphinx/usage.rst
+++ b/src/site/sphinx/usage.rst
@@ -1540,6 +1540,13 @@ this new type instead::
 Passing ``--lang "C++"`` just works as expected.
 Please note that ``--lang CPP`` no longer works in this case.
 
+To use case-insensitive matching of enum value names, use either
+|Arguments.caseInsensitiveEnumType| (uses ``name()``) or
+|Arguments.caseInsensitiveEnumStringType| (uses ``toString()``). Note
+that ``Locale.ROOT`` is used for case-insensitive comparison to
+ensure that correct parsing of arguments is not dependent on the
+locale of the parser.
+
 The |Argument.type| has a version which accepts an object which
 implements :javadoc:`inf.ArgumentType` interface::
 
@@ -2821,6 +2828,8 @@ available:
 .. |ArgumentParsers.newFor| replace:: :javadocfunc:`ArgumentParsers.newFor(java.lang.String)`
 .. |Arguments.appendConst| replace:: :javadocfunc:`impl.Arguments.appendConst()`
 .. |Arguments.append| replace:: :javadocfunc:`impl.Arguments.append()`
+.. |Arguments.caseInsensitiveEnumType| replace:: :javadocfunc:`impl.Arguments.caseInsensitiveEnumType(java.lang.Class)`
+.. |Arguments.caseInsensitiveEnumStringType| replace:: :javadocfunc:`impl.Arguments.caseInsensitiveEnumStringType(java.lang.Class)`
 .. |Arguments.count| replace:: :javadocfunc:`impl.Arguments.count()`
 .. |Arguments.enumStringType| replace:: :javadocfunc:`impl.Arguments.enumStringType(java.lang.Class)`
 .. |Arguments.fileType| replace:: :javadocfunc:`impl.Arguments.fileType()`

--- a/src/test/java/net/sourceforge/argparse4j/impl/type/CaseInsensitiveEnumNameArgumentTypeTest.java
+++ b/src/test/java/net/sourceforge/argparse4j/impl/type/CaseInsensitiveEnumNameArgumentTypeTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2015 andrewj
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.sourceforge.argparse4j.impl.type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Locale;
+
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.mock.MockArgument;
+
+import org.junit.Test;
+
+public class CaseInsensitiveEnumNameArgumentTypeTest {
+
+    enum Lang {
+        PYTHON, JAVA, CPP {
+            @Override
+            public String toString() {
+                return "C++";
+            }
+        }, INTERLISP
+    }
+
+    @Test
+    public void testConvert() throws ArgumentParserException {
+        ArgumentParser ap = ArgumentParsers.newFor("argparse4j")
+                .locale(Locale.US).build();
+        CaseInsensitiveEnumNameArgumentType<Lang> type = CaseInsensitiveEnumNameArgumentType
+                .forEnum(Lang.class);
+        assertEquals(Lang.PYTHON, type.convert(ap, null, "PYTHON"));
+        assertEquals(Lang.PYTHON, type.convert(ap, null, "Python"));
+        assertEquals(Lang.PYTHON, type.convert(ap, null, "pYTHON"));
+        assertEquals(Lang.JAVA, type.convert(ap, null, "JAVA"));
+        assertEquals(Lang.CPP, type.convert(ap, null, "CPP"));
+        assertEquals(Lang.INTERLISP, type.convert(ap, null, "INTERLISP"));
+    }
+
+    @Test
+    public void testConvertErrorsWithUnknownMember() throws ArgumentParserException {
+        ArgumentParser ap = ArgumentParsers.newFor("argparse4j")
+                .locale(Locale.US).build();
+        CaseInsensitiveEnumNameArgumentType<Lang> type = CaseInsensitiveEnumNameArgumentType
+                .forEnum(Lang.class);
+        try {
+            type.convert(ap, new MockArgument(), "C++");
+            fail("Expected ArgumentParserException to be thrown");
+        } catch (ArgumentParserException e) {
+            assertEquals(
+                    "argument null: could not convert 'C++' (choose from {PYTHON,JAVA,CPP,INTERLISP})",
+                    e.getMessage());
+        }
+    }
+    
+    @Test
+    public void testIgnoresLocaleOfParserForCaseInsensitivity() throws
+            ArgumentParserException {
+        ArgumentParser ap = ArgumentParsers.newFor("argparse4j")
+                .locale(new Locale("tr")).build();
+        CaseInsensitiveEnumNameArgumentType<Lang> type = CaseInsensitiveEnumNameArgumentType
+                .forEnum(Lang.class);
+        try {
+            type.convert(ap, new MockArgument(), "ıNTERLISP");
+            fail("Expected ArgumentParserException to be thrown");
+        } catch (ArgumentParserException e) {
+            assertEquals(
+                    "argument null: could not convert 'ıNTERLISP' (choose from {PYTHON,JAVA,CPP,INTERLISP})",
+                    e.getMessage());
+        }
+    }
+}

--- a/src/test/java/net/sourceforge/argparse4j/impl/type/CaseInsensitiveEnumStringArgumentTypeTest.java
+++ b/src/test/java/net/sourceforge/argparse4j/impl/type/CaseInsensitiveEnumStringArgumentTypeTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2015 andrewj
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.sourceforge.argparse4j.impl.type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Locale;
+
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.mock.MockArgument;
+
+import org.junit.Test;
+
+public class CaseInsensitiveEnumStringArgumentTypeTest {
+
+    enum Lang {
+        PYTHON, JAVA, CPP {
+            @Override
+            public String toString() {
+                return "C++";
+            }
+        }, INTERLISP {
+            @Override
+            public String toString() {
+                return "Interlisp";
+            }
+        }
+    }
+
+    @Test
+    public void testConvert() throws ArgumentParserException {
+        ArgumentParser ap = ArgumentParsers.newFor("argparse4j")
+                .locale(Locale.US).build();
+        CaseInsensitiveEnumStringArgumentType<Lang> type = CaseInsensitiveEnumStringArgumentType
+                .forEnum(Lang.class);
+        assertEquals(Lang.PYTHON, type.convert(ap, null, "PYTHON"));
+        assertEquals(Lang.PYTHON, type.convert(ap, null, "Python"));
+        assertEquals(Lang.PYTHON, type.convert(ap, null, "pYTHON"));
+        assertEquals(Lang.JAVA, type.convert(ap, null, "JAVA"));
+        assertEquals(Lang.CPP, type.convert(ap, null, "C++"));
+        assertEquals(Lang.INTERLISP, type.convert(ap, null, "INTERLISP"));
+    }
+
+    @Test
+    public void testConvertErrorsWithUnknownMember() throws ArgumentParserException {
+        ArgumentParser ap = ArgumentParsers.newFor("argparse4j")
+                .locale(Locale.US).build();
+        CaseInsensitiveEnumStringArgumentType<Lang> type = CaseInsensitiveEnumStringArgumentType
+                .forEnum(Lang.class);
+        try {
+            type.convert(ap, new MockArgument(), "CPP");
+            fail("Expected ArgumentParserException to be thrown");
+        } catch (ArgumentParserException e) {
+            assertEquals(
+                    "argument null: could not convert 'CPP' (choose from {PYTHON,JAVA,C++,Interlisp})",
+                    e.getMessage());
+        }
+    }
+    
+    @Test
+    public void testIgnoresLocaleOfParserForCaseInsensitivity() throws
+            ArgumentParserException {
+        ArgumentParser ap = ArgumentParsers.newFor("argparse4j")
+                .locale(new Locale("tr")).build();
+        CaseInsensitiveEnumStringArgumentType<Lang> type = CaseInsensitiveEnumStringArgumentType
+                .forEnum(Lang.class);
+        try {
+            type.convert(ap, new MockArgument(), "ınterlisp");
+            fail("Expected ArgumentParserException to be thrown");
+        } catch (ArgumentParserException e) {
+            assertEquals(
+                    "argument null: could not convert 'ınterlisp' (choose from {PYTHON,JAVA,C++,Interlisp})",
+                    e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
The argument types use `Locale.ROOT` to ensure that parsing is the same no matter what the locale of the parser is (which I assume to be the locale of the user in most cases). This may be confusing to users whose language uses different upper-to-lower case conversions than those used by `Locale.ROOT`.

For example, in Turkish, the lower case version of `Interlisp` is `ınterlisp`, but the Turkish speaker would have to enter `interlisp` instead: http://www.i18nguy.com/unicode/turkish-i18n.html